### PR TITLE
Erro biblioteca padrão

### DIFF
--- a/main.c
+++ b/main.c
@@ -1,4 +1,4 @@
-#include "projeto.h"
+#include "Projeto.h" // o nome correto para o arquivo de cabeçalho é "Projeto.h"
 #include "stdio.h"
 
 int main(){

--- a/main.c
+++ b/main.c
@@ -1,5 +1,5 @@
 #include "Projeto.h" // o nome correto para o arquivo de cabeçalho é "Projeto.h"
-#include "stdio.h"
+#include <stdio.h> // o correto para bibliotecas padrão é ultilizar <>
 
 int main(){
 ListaDeTarefas lt;


### PR DESCRIPTION
Para se referir a bibliotecas padrão se usa <>, e não ""